### PR TITLE
Fix JSON parsing error when the decimal separator is a comma

### DIFF
--- a/AltiumScript/json_utils.pas
+++ b/AltiumScript/json_utils.pas
@@ -142,7 +142,7 @@ end;
 // Helper to add a numeric property
 procedure AddJSONNumber(List: TStringList; Name: String; Value: Double);
 begin
-    List.Add(JSONPairStr(Name, FloatToStr(Value), False));
+    List.Add(JSONPairStr(Name, StringReplace(FloatToStr(Value), ',', '.', REPLACEALL), False));
 end;
 
 // Helper to add an integer property


### PR DESCRIPTION
Unfortunately I couldn't figure out how to change the locale in DelphiScript in Altium, nor how to force `FloatToString` or `FormatFloat` to output comma. So, this is the solution I came up with.

Fixes #2