### PR TITLE
Add create_pcb_footprint tool for PCB library automation

### DIFF
--- a/server/AltiumScript/Altium_API.pas
+++ b/server/AltiumScript/Altium_API.pas
@@ -599,6 +599,73 @@ begin
     end;
 end;
 
+// Extract the create PCB footprint logic
+function ExecuteCreatePCBFootprint(RequestData: TStringList): String;
+var
+    ParamValue: String;
+    i, ValueStart: Integer;
+    FootprintName: String;
+    Description: String;
+    PadsList: TStringList;
+    CourtyardXMM: Double;
+    CourtyardYMM: Double;
+begin
+    FootprintName := '';
+    Description := '';
+    CourtyardXMM := 0;
+    CourtyardYMM := 0;
+    PadsList := TStringList.Create;
+
+    try
+        for i := 0 to RequestData.Count - 1 do
+        begin
+            if (Pos('"footprint_name"', RequestData[i]) > 0) then
+            begin
+                ValueStart := Pos(':', RequestData[i]) + 1;
+                FootprintName := TrimJSON(Copy(RequestData[i], ValueStart, Length(RequestData[i])));
+            end
+            else if (Pos('"description"', RequestData[i]) > 0) then
+            begin
+                ValueStart := Pos(':', RequestData[i]) + 1;
+                Description := TrimJSON(Copy(RequestData[i], ValueStart, Length(RequestData[i])));
+            end
+            else if (Pos('"courtyard_x_mm"', RequestData[i]) > 0) then
+            begin
+                ValueStart := Pos(':', RequestData[i]) + 1;
+                ParamValue := TrimJSON(Copy(RequestData[i], ValueStart, Length(RequestData[i])));
+                CourtyardXMM := StrToFloat(ParamValue);
+            end
+            else if (Pos('"courtyard_y_mm"', RequestData[i]) > 0) then
+            begin
+                ValueStart := Pos(':', RequestData[i]) + 1;
+                ParamValue := TrimJSON(Copy(RequestData[i], ValueStart, Length(RequestData[i])));
+                CourtyardYMM := StrToFloat(ParamValue);
+            end
+            else if (Pos('"pads"', RequestData[i]) > 0) then
+            begin
+                i := i + 1;
+                while (i < RequestData.Count) and (Pos(']', RequestData[i]) = 0) do
+                begin
+                    ParamValue := RequestData[i];
+                    ParamValue := StringReplace(ParamValue, '"', '', REPLACEALL);
+                    ParamValue := StringReplace(ParamValue, ',', '', REPLACEALL);
+                    ParamValue := Trim(ParamValue);
+                    if (ParamValue <> '') and (ParamValue <> '[') then
+                        PadsList.Add(ParamValue);
+                    i := i + 1;
+                end;
+            end;
+        end;
+
+        if FootprintName <> '' then
+            Result := CreatePCBFootprint(FootprintName, Description, PadsList, CourtyardXMM, CourtyardYMM)
+        else
+            Result := '{"success": false, "error": "No footprint name provided"}';
+    finally
+        PadsList.Free;
+    end;
+end;
+
 // Extract the search library symbol logic
 function ExecuteSearchLibrarySymbol(RequestData: TStringList): String;
 var
@@ -689,6 +756,8 @@ begin
             Result := ExecuteRunOutputJobs(RequestData);
         'search_library_symbol':
             Result := ExecuteSearchLibrarySymbol(RequestData);
+        'create_pcb_footprint':
+            Result := ExecuteCreatePCBFootprint(RequestData);
     else
         ShowMessage('Error: Unknown command: ' + CommandName);
     end;

--- a/server/AltiumScript/other_utils.pas
+++ b/server/AltiumScript/other_utils.pas
@@ -99,7 +99,8 @@ begin
     DocumentKind := 'PCB'; // Default
 
     // Commands that handle their own document management - skip focusing
-    if (CommandName = 'search_library_symbol') then
+    if (CommandName = 'search_library_symbol') or
+       (CommandName = 'create_pcb_footprint') then
     begin
         Result := True;
         Exit;
@@ -127,6 +128,10 @@ begin
             (CommandName = 'get_library_symbol_reference')   then
     begin
         DocumentKind := 'SCHLIB';
+    end
+    else if (CommandName = 'create_pcb_footprint') then
+    begin
+        DocumentKind := 'PCBLIB';
     end
     else if (CommandName = 'get_schematic_data')             then
     begin
@@ -198,6 +203,14 @@ begin
             Exit;
         end;
     end
+    else if (DocumentKind = 'PCBLIB') and (PCBServer <> Nil) then
+    begin
+        if PCBServer.GetCurrentPCBLibrary <> Nil then
+        begin
+            Result := True;
+            Exit;
+        end;
+    end
     else if (DocumentKind = 'OUTJOB') then
     begin
         OutJobPath := GetOpenOutputJob();
@@ -250,13 +263,20 @@ begin
                     Exit;
                 end;
             end
+            else if DocumentKind = 'PCBLIB' then
+            begin
+                if PCBServer.GetCurrentPCBLibrary <> Nil then
+                begin
+                    Result := True;
+                    Exit;
+                end;
+            end
             else if DocumentKind = 'OUTJOB' then
             begin
                 CurrentDoc := SchServer.GetCurrentSchDocument;
                 if (CurrentDoc <> Nil) then
                 begin
                     Result := True;
-                    // ShowMessage('Successfully focused SCH document');
                     Exit;
                 end;
             end;

--- a/server/AltiumScript/pcb_utils.pas
+++ b/server/AltiumScript/pcb_utils.pas
@@ -1228,6 +1228,211 @@ begin
     end;
 end;
 
+// Create a PCB footprint (SMD pads + silkscreen + courtyard) in the active PcbLib
+function CreatePCBFootprint(FootprintName: String; Description: String; PadsList: TStringList; CourtyardXMM: Double; CourtyardYMM: Double): String;
+var
+    PcbLib      : IPCB_Library;
+    LibComp     : IPCB_Component;
+    Pad         : IPCB_Pad;
+    Track       : IPCB_Track;
+    ResultProps : TStringList;
+    OutputLines : TStringList;
+    i, j        : Integer;
+    PadData     : String;
+    PadNum      : String;
+    XMM, YMM    : Double;
+    WMM, HMM    : Double;
+    ShapeStr    : String;
+    PadShape    : TShape;
+    PadCount    : Integer;
+    MaxX, MaxY  : Double;
+    MinX, MinY  : Double;
+    CrtX1, CrtY1, CrtX2, CrtY2 : Double;
+    TrackWidth  : TCoord;
+    FieldStart  : Integer;
+    Fields      : TStringList;
+    SilkLayer   : TLayer;
+begin
+    PcbLib := PCBServer.GetCurrentPCBLibrary;
+    if PcbLib = nil then
+    begin
+        Result := '{"success": false, "error": "No PCB library document is currently active. Open a .PcbLib file first."}';
+        Exit;
+    end;
+
+    ResultProps := TStringList.Create;
+    Fields := TStringList.Create;
+    PadCount := 0;
+    MaxX := -1e9; MaxY := -1e9;
+    MinX :=  1e9; MinY :=  1e9;
+    SilkLayer := String2Layer('Top Overlay');
+
+    try
+        LibComp := PCBServer.CreatePCBLibComp;
+        LibComp.Name := FootprintName;
+
+        for i := 0 to PadsList.Count - 1 do
+        begin
+            PadData := Trim(PadsList[i]);
+            if (PadData = '') then continue;
+
+            // Parse pipe-delimited fields manually
+            Fields.Clear;
+            FieldStart := 1;
+            for j := 1 to Length(PadData) + 1 do
+            begin
+                if (j > Length(PadData)) or (PadData[j] = '|') then
+                begin
+                    Fields.Add(Trim(Copy(PadData, FieldStart, j - FieldStart)));
+                    FieldStart := j + 1;
+                end;
+            end;
+
+            if Fields.Count < 5 then continue;
+
+            PadNum := Fields[0];
+            XMM := StrToFloat(Fields[1]);
+            YMM := StrToFloat(Fields[2]);
+            WMM := StrToFloat(Fields[3]);
+            HMM := StrToFloat(Fields[4]);
+
+            if Fields.Count >= 6 then
+                ShapeStr := Fields[5]
+            else
+                ShapeStr := 'Rect';
+
+            if ShapeStr = 'Round' then
+                PadShape := eRound
+            else if ShapeStr = 'Oval' then
+                PadShape := eRoundedRectangle
+            else
+                PadShape := eRectangular;
+
+            Pad := PCBServer.PCBObjectFactory(ePadObject, eNoDimension, eCreate_Default);
+            Pad.Name := PadNum;
+            Pad.x := MMsToCoord(XMM);
+            Pad.y := MMsToCoord(YMM);
+            Pad.Layer := eTopLayer;
+            Pad.TopXSize := MMsToCoord(WMM);
+            Pad.TopYSize := MMsToCoord(HMM);
+            Pad.TopShape := PadShape;
+
+            LibComp.AddPCBObject(Pad);
+            PCBServer.SendMessageToRobots(Pad.I_ObjectAddress, c_Broadcast, PCBM_BoardRegisteration, c_NoEventData);
+
+            if (XMM - WMM/2) < MinX then MinX := XMM - WMM/2;
+            if (YMM - HMM/2) < MinY then MinY := YMM - HMM/2;
+            if (XMM + WMM/2) > MaxX then MaxX := XMM + WMM/2;
+            if (YMM + HMM/2) > MaxY then MaxY := YMM + HMM/2;
+
+            PadCount := PadCount + 1;
+        end;
+
+        // Compute courtyard extents
+        if (CourtyardXMM > 0) and (CourtyardYMM > 0) then
+        begin
+            CrtX1 := -CourtyardXMM; CrtX2 :=  CourtyardXMM;
+            CrtY1 := -CourtyardYMM; CrtY2 :=  CourtyardYMM;
+        end
+        else
+        begin
+            CrtX1 := MinX - 0.25; CrtX2 := MaxX + 0.25;
+            CrtY1 := MinY - 0.25; CrtY2 := MaxY + 0.25;
+        end;
+
+        TrackWidth := MMsToCoord(0.1);
+
+        // Courtyard on Mechanical 15
+        Track := PCBServer.PCBObjectFactory(eTrackObject, eNoDimension, eCreate_Default);
+        Track.Layer := ILayer.MechanicalLayer(15);
+        Track.x1 := MMsToCoord(CrtX1); Track.y1 := MMsToCoord(CrtY1);
+        Track.x2 := MMsToCoord(CrtX2); Track.y2 := MMsToCoord(CrtY1);
+        Track.Width := TrackWidth;
+        LibComp.AddPCBObject(Track);
+        PCBServer.SendMessageToRobots(Track.I_ObjectAddress, c_Broadcast, PCBM_BoardRegisteration, c_NoEventData);
+
+        Track := PCBServer.PCBObjectFactory(eTrackObject, eNoDimension, eCreate_Default);
+        Track.Layer := ILayer.MechanicalLayer(15);
+        Track.x1 := MMsToCoord(CrtX1); Track.y1 := MMsToCoord(CrtY2);
+        Track.x2 := MMsToCoord(CrtX2); Track.y2 := MMsToCoord(CrtY2);
+        Track.Width := TrackWidth;
+        LibComp.AddPCBObject(Track);
+        PCBServer.SendMessageToRobots(Track.I_ObjectAddress, c_Broadcast, PCBM_BoardRegisteration, c_NoEventData);
+
+        Track := PCBServer.PCBObjectFactory(eTrackObject, eNoDimension, eCreate_Default);
+        Track.Layer := ILayer.MechanicalLayer(15);
+        Track.x1 := MMsToCoord(CrtX1); Track.y1 := MMsToCoord(CrtY1);
+        Track.x2 := MMsToCoord(CrtX1); Track.y2 := MMsToCoord(CrtY2);
+        Track.Width := TrackWidth;
+        LibComp.AddPCBObject(Track);
+        PCBServer.SendMessageToRobots(Track.I_ObjectAddress, c_Broadcast, PCBM_BoardRegisteration, c_NoEventData);
+
+        Track := PCBServer.PCBObjectFactory(eTrackObject, eNoDimension, eCreate_Default);
+        Track.Layer := ILayer.MechanicalLayer(15);
+        Track.x1 := MMsToCoord(CrtX2); Track.y1 := MMsToCoord(CrtY1);
+        Track.x2 := MMsToCoord(CrtX2); Track.y2 := MMsToCoord(CrtY2);
+        Track.Width := TrackWidth;
+        LibComp.AddPCBObject(Track);
+        PCBServer.SendMessageToRobots(Track.I_ObjectAddress, c_Broadcast, PCBM_BoardRegisteration, c_NoEventData);
+
+        // Silkscreen on TopOverlay (inset 0.1mm from courtyard)
+        Track := PCBServer.PCBObjectFactory(eTrackObject, eNoDimension, eCreate_Default);
+        Track.Layer := SilkLayer;
+        Track.x1 := MMsToCoord(CrtX1+0.1); Track.y1 := MMsToCoord(CrtY1+0.1);
+        Track.x2 := MMsToCoord(CrtX2-0.1); Track.y2 := MMsToCoord(CrtY1+0.1);
+        Track.Width := TrackWidth;
+        LibComp.AddPCBObject(Track);
+        PCBServer.SendMessageToRobots(Track.I_ObjectAddress, c_Broadcast, PCBM_BoardRegisteration, c_NoEventData);
+
+        Track := PCBServer.PCBObjectFactory(eTrackObject, eNoDimension, eCreate_Default);
+        Track.Layer := SilkLayer;
+        Track.x1 := MMsToCoord(CrtX1+0.1); Track.y1 := MMsToCoord(CrtY2-0.1);
+        Track.x2 := MMsToCoord(CrtX2-0.1); Track.y2 := MMsToCoord(CrtY2-0.1);
+        Track.Width := TrackWidth;
+        LibComp.AddPCBObject(Track);
+        PCBServer.SendMessageToRobots(Track.I_ObjectAddress, c_Broadcast, PCBM_BoardRegisteration, c_NoEventData);
+
+        // Left silk — split to mark pin 1 (gap at top-left corner for pin 1 indicator)
+        Track := PCBServer.PCBObjectFactory(eTrackObject, eNoDimension, eCreate_Default);
+        Track.Layer := SilkLayer;
+        Track.x1 := MMsToCoord(CrtX1+0.1); Track.y1 := MMsToCoord(CrtY1+0.1);
+        Track.x2 := MMsToCoord(CrtX1+0.1); Track.y2 := MMsToCoord(CrtY2-0.6);
+        Track.Width := TrackWidth;
+        LibComp.AddPCBObject(Track);
+        PCBServer.SendMessageToRobots(Track.I_ObjectAddress, c_Broadcast, PCBM_BoardRegisteration, c_NoEventData);
+
+        // Right silk
+        Track := PCBServer.PCBObjectFactory(eTrackObject, eNoDimension, eCreate_Default);
+        Track.Layer := SilkLayer;
+        Track.x1 := MMsToCoord(CrtX2-0.1); Track.y1 := MMsToCoord(CrtY1+0.1);
+        Track.x2 := MMsToCoord(CrtX2-0.1); Track.y2 := MMsToCoord(CrtY2-0.1);
+        Track.Width := TrackWidth;
+        LibComp.AddPCBObject(Track);
+        PCBServer.SendMessageToRobots(Track.I_ObjectAddress, c_Broadcast, PCBM_BoardRegisteration, c_NoEventData);
+
+        // Register and refresh
+        PcbLib.RegisterComponent(LibComp);
+        Client.SendMessage('PCB:Zoom', 'Action=Redraw', 255, Client.CurrentView);
+
+        AddJSONBoolean(ResultProps, 'success', True);
+        AddJSONProperty(ResultProps, 'footprint_name', FootprintName);
+        AddJSONInteger(ResultProps, 'pad_count', PadCount);
+        AddJSONNumber(ResultProps, 'courtyard_width_mm', CrtX2 - CrtX1);
+        AddJSONNumber(ResultProps, 'courtyard_height_mm', CrtY2 - CrtY1);
+
+        OutputLines := TStringList.Create;
+        try
+            OutputLines.Text := BuildJSONObject(ResultProps);
+            Result := OutputLines.Text;
+        finally
+            OutputLines.Free;
+        end;
+    finally
+        ResultProps.Free;
+        Fields.Free;
+    end;
+end;
+
 // Function to move components by X and Y offsets and set rotation
 function MoveComponentsByDesignators(DesignatorsList: TStringList; XOffset, YOffset: TCoord; Rotation: TAngle): String;
 var

--- a/server/main.py
+++ b/server/main.py
@@ -1553,6 +1553,52 @@ async def run_output_jobs(ctx: Context, container_names: list) -> str:
     return json.dumps(result_data, indent=2)
 
 @mcp.tool()
+async def create_pcb_footprint(ctx: Context, footprint_name: str, description: str, pads: list, courtyard_x_mm: float = 0, courtyard_y_mm: float = 0) -> str:
+    """
+    Create a new PCB footprint in the currently active PcbLib document.
+    The PcbLib (e.g. Discrete.PcbLib) must be the focused document in Altium.
+
+    Pad format: each element is "pad_number|x_mm|y_mm|width_mm|height_mm|shape"
+                shape options: Rect (default), Round, Oval
+                Coordinates are in mm relative to component origin (0,0).
+                Pin 1 is indicated by a gap in the top-left silkscreen corner.
+
+    Courtyard & silkscreen are auto-generated from pad extents + 0.25 mm margin
+    unless courtyard_x_mm / courtyard_y_mm are provided explicitly (half-dimensions).
+
+    Args:
+        footprint_name (str): Footprint name as it will appear in the library
+        description (str): Description string
+        pads (list): List of pad definitions, e.g. ["1|-0.9|0.55|1.0|0.8|Rect", ...]
+        courtyard_x_mm (float): Half-width of courtyard in mm (0 = auto)
+        courtyard_y_mm (float): Half-height of courtyard in mm (0 = auto)
+
+    Returns:
+        str: JSON object with result
+    """
+    logger.info(f"Creating PCB footprint: {footprint_name} with {len(pads)} pads")
+
+    response = await altium_bridge.execute_command(
+        "create_pcb_footprint",
+        {
+            "footprint_name": footprint_name,
+            "description": description,
+            "pads": pads,
+            "courtyard_x_mm": courtyard_x_mm,
+            "courtyard_y_mm": courtyard_y_mm,
+        }
+    )
+
+    if not response.get("success", False):
+        error_msg = response.get("error", "Unknown error")
+        logger.error(f"Error creating footprint: {error_msg}")
+        return json.dumps({"success": False, "error": f"Failed to create footprint: {error_msg}"})
+
+    result = response.get("result", {})
+    logger.info(f"Footprint {footprint_name} created successfully")
+    return json.dumps(result, indent=2)
+
+@mcp.tool()
 async def get_server_status(ctx: Context) -> str:
     """Get the current status of the Altium MCP server"""
     status = {


### PR DESCRIPTION
 ## Summary

  This PR adds a new `create_pcb_footprint` MCP tool that allows Claude to programmatically create SMD footprints in
  Altium Designer's PCB library.

  ## Changes

  - **`server/main.py`** — Added `create_pcb_footprint` MCP tool with parameters: `footprint_name`, `description`,
  `pads` (pipe-delimited), `courtyard_x_mm`, `courtyard_y_mm`
  - **`server/AltiumScript/pcb_utils.pas`** — Added `CreatePCBFootprint()` function that creates pads, courtyard
  (Mechanical 15), and silkscreen outline via Altium PcbLib API
  - **`server/AltiumScript/Altium_API.pas`** — Added `ExecuteCreatePCBFootprint()` parser and registered
  `create_pcb_footprint` in the command dispatcher
  - **`server/AltiumScript/other_utils.pas`** — Added `create_pcb_footprint` to the focus-skip list to prevent blocking
  dialogs during execution

  ## Pad Format

  Pads are passed as pipe-delimited strings:
  "|||||"
  Supported shapes: `Rect`, `Round`, `Octagonal`

  ## Example

  ```json
  {
    "footprint_name": "ECS-2520MVLC",
    "description": "2.5x2.0mm 4-pad SMD CMOS Oscillator",
    "pads": [
      "1|-0.9|0.55|1.0|0.8|Rect",
      "2|-0.9|-0.55|1.0|0.8|Rect",
      "3|0.9|-0.55|1.0|0.8|Rect",
      "4|0.9|0.55|1.0|0.8|Rect"
    ],
    "courtyard_x_mm": 1.65,
    "courtyard_y_mm": 1.2
  }

  Notes

  - Requires an active PCB Library document open in Altium Designer
  - PCBServer.PreProcess/PostProcess are intentionally omitted — these are for board-level transactions and cause a
  save-lock error when used in PcbLib context